### PR TITLE
Replace Google Calendar embed with RAW TALK calendar rather than Group calendar

### DIFF
--- a/events.html
+++ b/events.html
@@ -31,7 +31,7 @@
             <div class="section">
                 <!-- calendar panel -->
                 
-                <iframe id="calendar__iframe" src="https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23e3e9fe&amp;ctz=Europe%2FLondon&amp;src=cjEzZ2s4OW1vbG1vbjl2OTg5dm9vcGFzbnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23039BE5&amp;mode=AGENDA&amp;showTitle=0&amp;showDate=0&amp;showNav=1&amp;showTabs=1&amp;showPrint=0&amp;showCalendars=0" style="border-width:0" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
+                <iframe id="calendar__iframe" src="https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23e3e9fe&amp;ctz=Europe%2FLondon&amp;src=dTdrNWp1NTFqbm45bTlpZGwzcjhtYTA5bGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23039BE5&amp;mode=AGENDA&amp;showTitle=0&amp;showDate=0&amp;showNav=1&amp;showTabs=1&amp;showPrint=0&amp;showCalendars=0" style="border-width:0" width="100%" height="400" frameborder="0" scrolling="no"></iframe>
             </div>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -722,20 +722,22 @@ fetch(calendar_url)
     .then(function() {
         calendarItemContainer.style.transition = 'inherit'
     })
-    .catch(function() {
-        calendarItemContainer.innerHTML = `
-            <div class="section">
-                <iframe id="calendar__iframe" 
-                    src="https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23e3e9fe&amp;ctz=Europe%2FLondon&amp;src=cjEzZ2s4OW1vbG1vbjl2OTg5dm9vcGFzbnNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23039BE5&amp;mode=AGENDA&amp;showTitle=0&amp;showDate=0&amp;showNav=1&amp;showTabs=1&amp;showPrint=0&amp;showCalendars=0" style="border-width:0" width="100%" height="150" frameborder="0" scrolling="no">
-                </iframe>
-            </div>
-            `
-        calendarItemContainer.style.display = 'block'
-        calendarItemContainer.style.maxHeight = '1000px' // high value as max height
-    })
+    .catch(embedGoogleOldSchoolStyleCalendar)
 
 function time2HHMM(t) {
     return `${t.getHours().toString().padStart(2,'0')}:${t.getMinutes().toString().padStart(2,'0')}`
+}
+
+function embedGoogleOldSchoolStyleCalendar() {
+    calendarItemContainer.innerHTML = `
+        <div class="section">
+            <iframe id="calendar__iframe" 
+                src="https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23e3e9fe&amp;ctz=Europe%2FLondon&amp;src=dTdrNWp1NTFqbm45bTlpZGwzcjhtYTA5bGNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23039BE5&amp;mode=AGENDA&amp;showTitle=0&amp;showDate=0&amp;showNav=1&amp;showTabs=1&amp;showPrint=0&amp;showCalendars=0" style="border-width:0" width="100%" height="150" frameborder="0" scrolling="no">
+            </iframe>
+        </div>
+        `
+    calendarItemContainer.style.display = 'block'
+    calendarItemContainer.style.maxHeight = '1000px' // high value as max height
 }
 
 // typewriter loop


### PR DESCRIPTION
Previously, the calendar embed was showing the Group calendar instead of the RAW TALK calendar, 
so wrong events were appearing on the embed. 